### PR TITLE
Define a public API

### DIFF
--- a/src/creation_method.rs
+++ b/src/creation_method.rs
@@ -1,0 +1,30 @@
+// Copyright (c) 2017 FaultyRAM
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT
+// or http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! Rules for updating timestamps when a given path does not exist.
+
+use Builder;
+use item::Item;
+use std::io;
+use std::marker::PhantomData;
+use std::path::Path;
+
+/// Do not attempt to create an item that does not exist.
+pub struct NoCreate;
+
+/// Create an item non-recursively if it does not exist.
+pub struct NonRecursive<I: Item>(PhantomData<I>);
+
+/// Create an item recursively if it does not exist.
+pub struct Recursive<I: Item>(PhantomData<I>);
+
+/// A trait shared by filesystem creation methods.
+pub trait CreationMethod {
+    #[doc(hidden)]
+    /// Updates the timestamps for a filesystem path that does not yet exist.
+    fn touch_new<P: AsRef<Path>>(builder: &Builder, path: P) -> io::Result<()>;
+}

--- a/src/item.rs
+++ b/src/item.rs
@@ -1,0 +1,21 @@
+// Copyright (c) 2017 FaultyRAM
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT
+// or http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! Filesystem items, such as directories and files.
+
+/// A directory.
+pub struct Directory;
+
+/// A file.
+pub struct File;
+
+/// A trait shared by filesystem items.
+pub trait Item {}
+
+impl Item for Directory {}
+
+impl Item for File {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,14 +16,127 @@
 #![forbid(anonymous_parameters)]
 #![forbid(box_pointers)]
 #![forbid(fat_ptr_transmutes)]
-#![forbid(missing_copy_implementations)]
-#![forbid(missing_debug_implementations)]
 #![forbid(missing_docs)]
 #![forbid(trivial_casts)]
 #![forbid(trivial_numeric_casts)]
 #![forbid(unsafe_code)]
 #![forbid(unused_extern_crates)]
 #![forbid(unused_import_braces)]
-#![forbid(unused_qualifications)]
+#![deny(unused_qualifications)]
 #![forbid(unused_results)]
 #![forbid(variant_size_differences)]
+
+pub mod creation_method;
+pub mod item;
+mod sys;
+
+/// Re-exports of commonly-used functionality.
+pub mod prelude {
+    pub use Builder;
+    pub use creation_method::{CreationMethod, NoCreate, NonRecursive, Recursive};
+    pub use item::{Directory, File, Item};
+}
+
+use self::creation_method::CreationMethod;
+use std::io;
+use std::path::Path;
+use std::time::SystemTime;
+
+#[derive(Clone, Copy, Debug)]
+/// A builder for updating filesystem timestamps.
+pub struct Builder {
+    /// The new access timestamp.
+    ///
+    /// If this is `None`, the access timestamp will not be modified.
+    accessed: Option<SystemTime>,
+    /// The new modification timestamp.
+    ///
+    /// If this is `None`, the modification timestamp will not be modified.
+    modified: Option<SystemTime>,
+}
+
+/// Updates the timestamps for a filesystem path to the current system time, after resolving
+/// symbolic links.
+///
+/// If the path does not exist, the specified creation method will be used to create the path.
+///
+/// This wraps the functionality provided by the `Builder` type and is provided for convenience.
+/// For more fine-grained control, use `Builder` directly.
+pub fn touch<M: CreationMethod, P: AsRef<Path>>(path: P) -> io::Result<()> {
+    let now = SystemTime::now();
+    Builder::new()
+        .accessed(now)
+        .modified(now)
+        .touch::<M, P>(path)
+}
+
+/// Updates the timestamps for a filesystem path to the current system time, without resolving
+/// symbolic links.
+///
+/// If the path does not exist, the specified creation method will be used to create the path.
+///
+/// This wraps the functionality provided by the `Builder` type and is provided for convenience.
+/// For more fine-grained control, use `Builder` directly.
+pub fn touch_symlink<M: CreationMethod, P: AsRef<Path>>(path: P) -> io::Result<()> {
+    let now = SystemTime::now();
+    Builder::new()
+        .accessed(now)
+        .modified(now)
+        .touch_symlink::<M, P>(path)
+}
+
+impl Builder {
+    /// Creates a new builder with default values.
+    pub fn new() -> Self {
+        Self {
+            accessed: None,
+            modified: None,
+        }
+    }
+
+    /// The access timestamp to use when updating timestamps.
+    ///
+    /// If this method is not called, the access timestamp will not be updated.
+    pub fn accessed(&mut self, time: SystemTime) -> &mut Self {
+        self.accessed = Some(time);
+        self
+    }
+
+    /// The modification timestamp to use when updating timestamps.
+    ///
+    /// If this method is not called, the modification timestamp will not be updated.
+    pub fn modified(&mut self, time: SystemTime) -> &mut Self {
+        self.modified = Some(time);
+        self
+    }
+
+    /// Updates the timestamps for a filesystem path, after resolving symbolic links.
+    ///
+    /// If the path does not exist, the specified creation method will be used to create the path.
+    pub fn touch<M: CreationMethod, P: AsRef<Path>>(&self, path: P) -> io::Result<()> {
+        sys::touch_existing(self, &path).or_else(|e| if e.kind() == io::ErrorKind::NotFound {
+            M::touch_new::<P>(self, path)
+        } else {
+            Err(e)
+        })
+    }
+
+    /// Updates the timestamps for a filesystem path, without resolving symbolic links.
+    ///
+    /// If the path does not exist, the specified creation method will be used to create the path.
+    pub fn touch_symlink<M: CreationMethod, P: AsRef<Path>>(&self, path: P) -> io::Result<()> {
+        sys::touch_existing_symlink(self, &path).or_else(
+            |e| if e.kind() == io::ErrorKind::NotFound {
+                M::touch_new::<P>(self, path)
+            } else {
+                Err(e)
+            },
+        )
+    }
+}
+
+impl Default for Builder {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -1,0 +1,30 @@
+// Copyright (c) 2017 FaultyRAM
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT
+// or http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! Platform-specific utilities.
+
+use Builder;
+use std::io;
+use std::path::Path;
+
+/// Updates the timestamps for an already existing path, after resolving symbolic links.
+///
+/// # Failures
+///
+/// Fails if the path does not exist.
+pub fn touch_existing<P: AsRef<Path>>(_builder: &Builder, _path: P) -> io::Result<()> {
+    unimplemented!()
+}
+
+/// Updates the timestamps for an already existing path, without resolving symbolic links.
+///
+/// # Failures
+///
+/// Fails if the path does not exist.
+pub fn touch_existing_symlink<P: AsRef<Path>>(_builder: &Builder, _path: P) -> io::Result<()> {
+    unimplemented!()
+}


### PR DESCRIPTION
This defines the public API for this crate, which consists of the following items:

* A set of *filesystem items* (the `Directory` and `File` types) which implement `Item`
* A set of *creation methods* (the `NoCreate`, `NonRecursive` and `Recursive` types) which are generic over types that implement `Item`, and will implement `CreationMethod` in a platform-specific manner
* A `Builder` type for updating timestamps on paths
* Convenience wrappers around the `Builder` type for updating timestamps using the current system time