### PR TITLE
Add tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,6 @@ version = "0.2"
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.2"
+
+[dev-dependencies.tempdir]
+version = "0.3"


### PR DESCRIPTION
This adds a bunch of tests covering all the different ways of using `Builder`.

The `nocreate` test originally failed on Linux because its implementation of `utimensat` succeeds unconditionally if every timestamp passed to it is omitted; this adds a check for that which can be extended to other platforms if needed.